### PR TITLE
Snappy ticket cleanup

### DIFF
--- a/snappybouncer/fixtures/test_snappybouncer.json
+++ b/snappybouncer/fixtures/test_snappybouncer.json
@@ -66,5 +66,35 @@
             "contact_key": "dummycontact1",
             "response": "Message back from FAQ"
         }
+    },
+    {
+        "pk": 4,
+        "model": "snappybouncer.ticket",
+        "fields": {
+            "msisdn": "+27001",
+            "created_at": "2014-07-26T20:30:49Z",
+            "support_id": null,
+            "updated_at": "2014-07-26T20:32:24.396Z",
+            "support_nonce": null,
+            "conversation": 1,
+            "message": "Faulty - no nonce 1",
+            "contact_key": "dummycontact1",
+            "response": ""
+        }
+    },
+    {
+        "pk": 5,
+        "model": "snappybouncer.ticket",
+        "fields": {
+            "msisdn": "+27001",
+            "created_at": "2014-07-26T20:30:49Z",
+            "support_id": null,
+            "updated_at": "2014-07-26T20:32:24.396Z",
+            "support_nonce": null,
+            "conversation": 1,
+            "message": "Faulty - no nonce 2",
+            "contact_key": "dummycontact1",
+            "response": ""
+        }
     }
 ]

--- a/snappybouncer/tests.py
+++ b/snappybouncer/tests.py
@@ -60,7 +60,7 @@ class SnappyBouncerResourceTest(ResourceTestCase):
         self.assertEqual(conversations.count(), 1)
 
         tickets = Ticket.objects.all()
-        self.assertEqual(tickets.count(), 3)
+        self.assertEqual(tickets.count(), 5)
 
     def test_get_list_unauthorzied(self):
         self.assertHttpUnauthorized(
@@ -123,7 +123,7 @@ class SnappyBouncerResourceTest(ResourceTestCase):
             "/api/v1/snappybouncer/conversation/1/", json_item["conversation"])
         self.assertEqual("+271234", json_item["msisdn"])
         self.assertEqual(
-            "/api/v1/snappybouncer/ticket/4/", json_item["resource_uri"])
+            "/api/v1/snappybouncer/ticket/6/", json_item["resource_uri"])
 
     def test_post_ticket_bad_conversation(self):
         data = {

--- a/subscription/management/commands/snappy_ticket_cleanup.py
+++ b/subscription/management/commands/snappy_ticket_cleanup.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+from optparse import make_option
+from snappybouncer.models import Ticket
+
+
+class Command(BaseCommand):
+    help = "Remove all Snappy tickets from backend that lacks a nonce"
+    option_list = BaseCommand.option_list + (
+        make_option('--dry_run', action='store_true', default=False),
+    )
+
+    def handle(self, *args, **options):
+        tickets = Ticket.objects.filter(support_nonce=None)
+        counter = 0
+
+        self.stdout.write('Deleting tickets without support nonces...\n')
+        self.stdout.write('Nonceless tickets found: %s\n' % tickets.count())
+
+        for ticket in tickets:
+            if not options["dry_run"]:
+                ticket.delete()
+                counter += 1
+
+        self.stdout.write('Deleted %s tickets' % counter)

--- a/subscription/management/commands/snappy_ticket_cleanup.py
+++ b/subscription/management/commands/snappy_ticket_cleanup.py
@@ -11,14 +11,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         tickets = Ticket.objects.filter(support_nonce=None)
-        counter = 0
+        counter = tickets.count()
 
-        self.stdout.write('Deleting tickets without support nonces...\n')
-        self.stdout.write('Nonceless tickets found: %s\n' % tickets.count())
+        self.stdout.write('Finding tickets without support nonces...\n')
+        self.stdout.write('Nonceless tickets found: %s\n' % counter)
 
-        for ticket in tickets:
-            if not options["dry_run"]:
-                ticket.delete()
-                counter += 1
-
-        self.stdout.write('Deleted %s tickets' % counter)
+        if not options["dry_run"]:
+            tickets.delete()
+            self.stdout.write('Deleted %s tickets' % counter)
+        else:
+            self.stdout.write('%s tickets would be deleted' % counter)

--- a/subscription/management/commands/tests/test_snappy_ticket_cleanup.py
+++ b/subscription/management/commands/tests/test_snappy_ticket_cleanup.py
@@ -66,7 +66,7 @@ class TestSnappyTicketCleanupCommand(TestCase):
         command.handle(None, **options)
 
         self.assertEqual('\n'.join([
-            'Deleting tickets without support nonces...',
+            'Finding tickets without support nonces...',
             'Nonceless tickets found: 2',
             'Deleted 2 tickets'
         ]), command.stdout.getvalue().strip())

--- a/subscription/management/commands/tests/test_snappy_ticket_cleanup.py
+++ b/subscription/management/commands/tests/test_snappy_ticket_cleanup.py
@@ -1,0 +1,78 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.core import management
+from django.db.models.signals import post_save
+from StringIO import StringIO
+from snappybouncer.models import (UserAccount, Conversation, Ticket,
+                                  fire_snappy_if_new)
+from subscription.management.commands import snappy_ticket_cleanup
+
+
+class TestSnappyTicketCleanupCommand(TestCase):
+
+    def _replace_post_save_hooks(self):
+        has_listeners = lambda: post_save.has_listeners(Ticket)
+        assert has_listeners(), (
+            "Ticket model has no post_save listeners. Make sure"
+            " helpers cleaned up properly in earlier tests.")
+        post_save.disconnect(fire_snappy_if_new,
+                             sender=Ticket)
+        assert not has_listeners(), (
+            "Ticket model still has post_save listeners. Make sure"
+            " helpers cleaned up properly in earlier tests.")
+
+    def _restore_post_save_hooks(self):
+        has_listeners = lambda: post_save.has_listeners(Ticket)
+        assert not has_listeners(), (
+            "Ticket model still has post_save listeners. Make sure"
+            " helpers removed them properly in earlier tests.")
+        post_save.connect(
+            fire_snappy_if_new,
+            sender=Ticket)
+
+    def setUp(self):
+        super(TestSnappyTicketCleanupCommand, self).setUp()
+        self._replace_post_save_hooks()
+        management.call_command(
+            'loaddata', 'test_snappybouncer.json', verbosity=0)
+        self.command = self.mk_command()
+
+    def tearDown(self):
+        self._restore_post_save_hooks()
+
+    def mk_command(self):
+        command = snappy_ticket_cleanup.Command()
+        command.stdout = StringIO()
+        return command
+
+    @override_settings(VUMI_GO_API_TOKEN='token')
+    def test_data_loaded(self):
+        useraccounts = UserAccount.objects.all()
+        self.assertEqual(useraccounts.count(), 1)
+
+        conversations = Conversation.objects.all()
+        self.assertEqual(conversations.count(), 1)
+
+        tickets = Ticket.objects.all()
+        self.assertEqual(tickets.count(), 5)
+
+        nonceless = Ticket.objects.filter(support_nonce=None)
+        self.assertEqual(nonceless.count(), 2)
+
+    @override_settings(VUMI_GO_API_TOKEN='token')
+    def test_nonceless_tickets_deleted(self):
+        command = self.mk_command()
+        options = {"dry_run": None}
+        command.handle(None, **options)
+
+        self.assertEqual('\n'.join([
+            'Deleting tickets without support nonces...',
+            'Nonceless tickets found: 2',
+            'Deleted 2 tickets'
+        ]), command.stdout.getvalue().strip())
+
+        tickets = Ticket.objects.all()
+        self.assertEqual(tickets.count(), 3)
+
+        nonceless = Ticket.objects.filter(support_nonce=None)
+        self.assertEqual(nonceless.count(), 0)


### PR DESCRIPTION
Make a management command to remove all snappy tickets that do not have `nonce`s from the backend.
