### PR TITLE
Widgets are drawn too early

### DIFF
--- a/controlinterface/static/controlinterface/css/sapphire-theme.css
+++ b/controlinterface/static/controlinterface/css/sapphire-theme.css
@@ -1,0 +1,92 @@
+.sph-title {
+  color: #f2f2f2;
+  background: #3a3a3a;
+}
+.sph-axis {
+  /* .tick is a class set by d3 */
+}
+.sph-axis line,
+.sph-axis path {
+  stroke: #636363;
+}
+.sph-axis .tick text {
+  fill: #636363;
+}
+.sph-table {
+  border-spacing: 2px 0;
+  border-collapse: separate;
+}
+.sph-table td {
+  background: rgba(58, 58, 58, 0.07);
+}
+.sph-table tr:nth-child(2n) td {
+  background: rgba(58, 58, 58, 0.025);
+}
+.sph-table tr.sph-row-tfoot td {
+  border-top: 2px solid rgba(58, 58, 58, 0.16);
+}
+.sph-table tr td.sph-col-swatch {
+  padding: 0;
+  width: 12px;
+}
+.sph-table tr td.sph-col-none {
+  border-top: none;
+  background: transparent;
+}
+.sph-widget {
+  color: #3a3a3a;
+}
+.sph-chart-bars {
+  min-height: 180px;
+}
+.sph-axis-bars-y line {
+  stroke-width: 1px;
+  stroke: rgba(242, 242, 242, 0.5);
+}
+.sph-axis-bars-y path {
+  stroke: none;
+}
+.sph-sparkline-path {
+  stroke: #3a3a3a;
+  stroke-width: 4px;
+}
+.sph-sparkline-path-diff {
+  stroke-width: 4.5px;
+}
+.sph-last.sph-is-status-good .sph-summary-diff {
+  color: #2ca02c;
+}
+.sph-last.sph-is-status-good .sph-sparkline-path-diff {
+  stroke: #2ca02c;
+}
+.sph-last.sph-is-status-good .sph-sparkline-dot {
+  fill: #2ca02c;
+}
+.sph-last.sph-is-status-bad .sph-summary-diff {
+  color: #d62728;
+}
+.sph-last.sph-is-status-bad .sph-sparkline-path-diff {
+  stroke: #d62728;
+}
+.sph-last.sph-is-status-bad .sph-sparkline-dot {
+  fill: #d62728;
+}
+.sph-last.sph-is-status-neutral .sph-summary-diff {
+  color: #3a3a3a;
+}
+.sph-last.sph-is-status-neutral .sph-sparkline-path-diff {
+  stroke: #3a3a3a;
+}
+.sph-last.sph-is-status-neutral .sph-sparkline-dot {
+  fill: #3a3a3a;
+}
+.sph-lines-metric {
+  stroke-width: 2px;
+}
+.sph-axis-lines line {
+  stroke-width: 1px;
+  stroke: rgba(58, 58, 58, 0.07);
+}
+.sph-axis-lines path {
+  stroke: none;
+}

--- a/controlinterface/templates/controlinterface/base.html
+++ b/controlinterface/templates/controlinterface/base.html
@@ -56,7 +56,6 @@
             <li><a href="https://app.besnappy.com" target="_new"><span class="glyphicon glyphicon-send"></span> Helpdesk</a></li>
             <li><a href="/admin/"><span class="glyphicon glyphicon-wrench"></span> Admin</a></li>
           </ul>
-          <br><br><br><br><br><br><br><br><br>
           <img src="{% static "controlinterface/img/doh.png" %}" class="img-responsive" style="padding-left: 20px">
         </div>
         <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">

--- a/controlinterface/templates/controlinterface/index.html
+++ b/controlinterface/templates/controlinterface/index.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 <link rel="stylesheet" href="{% static "controlinterface/css/sapphire.css" %}">
+<link rel="stylesheet" href="{% static "controlinterface/css/sapphire-theme.css" %}">
 <div class="sapphire">
   <div class="row">
     <div class="col-sm-3 col-md-4">
@@ -49,12 +50,14 @@
           title: '{{ values.config.title }}',
           {% if values.data.count == 1 %}
           key: '{{ values.data.first.key }}',
+          values: [],
           {% else %}
           metrics: [
             {% for metric in values.data %}
             {
               title: '{{ metric.title}}',
-              key: '{{ metric.key}}'
+              key: '{{ metric.key}}',
+              values: []
             },
 
             {% endfor %}

--- a/controlinterface/templates/controlinterface/messages.html
+++ b/controlinterface/templates/controlinterface/messages.html
@@ -19,7 +19,7 @@
     {% endif %}
 
         {% if updateform %}
-          <form id="message-edit-form" method="post" method="POST" action="." class="form-horizontal" style="width: 500px">
+          <form id="message-edit-form" method="post" method="POST" action=".">
             {% csrf_token %}
           <h3>Edit message</h3>
           {{ updateform|bootstrap }}
@@ -27,7 +27,7 @@
           <input type="submit" class="btn btn-success" value="Update" />
           </form>
         {% elif confirmform %}
-          <form id="message-edit-form" method="post" method="POST" action="." class="form-horizontal" style="width: 500px">
+          <form id="message-edit-form" method="post" method="POST" action=".">
             {% csrf_token %}
           <h3>Confirm updated message</h3>
             {{ confirmform|bootstrap }}
@@ -36,7 +36,7 @@
             <button onclick="window.history.back()" class="btn btn-danger">Cancel</button>
           </form>
         {% elif form %}
-          <form id="message-edit-form" method="post" method="POST" action="." class="form-horizontal" style="width: 500px">
+          <form id="message-edit-form" method="post" method="POST" action=".">
           {% csrf_token %}
           <h3>Find a message to edit</h3>
           {{ form|bootstrap }}

--- a/controlinterface/templates/controlinterface/subscription.html
+++ b/controlinterface/templates/controlinterface/subscription.html
@@ -10,7 +10,7 @@
     </div>
   </div>
   <div class="row">
-
+    <div class="col-sm-8 col-md-8">
     {% if messages %}
 
     {% for message in messages %}
@@ -47,58 +47,53 @@
             </tbody>
         </table>
           <h4>Actions:</h4>
-          <p><form id="subscription-edit-form" method="post" method="POST" action="." class="form-horizontal">
+          <p><form id="subscription-edit-form" method="post" method="POST" action=".">
           {% csrf_token %}
           {{ confirmcancelform|bootstrap }}<input type="submit" class="btn btn-primary" value="Cancel All Subscriptions" />
           </form></p>
           <p>
-          <form id="subscription-edit-form" method="post" method="POST" action="." class="form-horizontal">
+          <form id="subscription-edit-form" method="post" method="POST" action=".">
           {% csrf_token %}
           {{ confirmbabyform|bootstrap }}<input type="submit" class="btn btn-primary" value="Switch To Baby" />
           </form></p>
 
     {% elif cancelform %}
-    <div class="col-sm-6 col-md-6">
           <h3>Confirm Subscription Cancel</h3>
-          <p><form id="subscription-edit-form" method="post" method="POST" action="." class="form-horizontal">
+          <p><form id="subscription-edit-form" method="post" method="POST" action=".">
             Cancelling all subscriptions will mean that the user will no longer receive any messages from MomConnect. Please confirm that you want to cancel all subscriptions for this user:<br><br>
           {% csrf_token %}
           {{ cancelform|bootstrap }}
           <input type="submit" class="btn btn-success" value="Cancel Subscriptions" />
           </form></p>
           <p>
-          <form id="subscription-edit-form" method="post" method="POST" action="." class="form-horizontal">
+          <form id="subscription-edit-form" method="post" method="POST" action=".">
           {% csrf_token %}
           {{ form|bootstrap }}<input type="submit" class="btn btn-danger" value="No, don't cancel subscriptions" />
           </form></p>
 
-    </div>
     {% elif babyform %}
-    <div class="col-sm-6 col-md-6">
           <h3>Confirm Baby Switch</h3>
-          <p><form id="subscription-edit-form" method="post" method="POST" action="." class="form-horizontal">
+          <p><form id="subscription-edit-form" method="post" method="POST" action=".">
             Switching a user to baby messages will mean that they will not receive any pregnancy messages anymore and will now start receiving messages about their baby. Mothers should have given birth to change to baby messages. Please confirm your choice:
           {% csrf_token %}
           {{ babyform|bootstrap }}
           <input type="submit" class="btn btn-success" value="Start baby messages" />
           </form></p>
           <p>
-          <form id="subscription-edit-form" method="post" method="POST" action="." class="form-horizontal">
+          <form id="subscription-edit-form" method="post" method="POST" action=".">
           {% csrf_token %}
           {{ form|bootstrap }}<input type="submit" class="btn btn-danger" value="No, don't start baby messages" />
           </form></p>
-    </div>
     {% else %}
-    <div class="col-sm-6 col-md-6">
-        <form id="subscription-edit-form" method="post" method="POST" action="." class="form-horizontal">
+        <form id="subscription-edit-form" method="post" method="POST" action=".">
           {% csrf_token %}
           <h3>Find a user to edit</h3>
           <p>Please Note: Cellphone number should be entered in the following format: <code>+27812345678</code></p>
           {{ form|bootstrap }}
           <input type="submit" class="btn btn-primary" value="Find" />
       </form>
-    </div>
     {% endif %}
+    </div>
   </div>
 
 {% endblock %}


### PR DESCRIPTION
Currently, request are made to the metrics api, then the widgets are drawn [immediately afterwards](https://github.com/praekelt/ndoh-control/blob/7fc4ba8f35096ab3c731ff336a6776967e6fb6d8/controlinterface/templates/controlinterface/index.html#L102-L103). Since `.values` is only set [on responses from the api](https://github.com/praekelt/ndoh-control/blob/7fc4ba8f35096ab3c731ff336a6776967e6fb6d8/controlinterface/templates/controlinterface/index.html#L159-L169), `.values` isn't present when the first draw happens, causing things to break.

This either needs to change to have `.values` present [from the start](https://gist.github.com/6a3d507204063808634a), or to [wait for values to appear before drawing](https://github.com/praekelt/go-metrics-api/blob/develop/examples/sapphire/example.js#L86-L87).

Changing this bit of code to work similar to [go-metrics-api#13](https://github.com/praekelt/go-metrics-api/pull/13/files) might help (that PR was created a while ago so that the example more closely matches how drawing is expected to happen in the control interface).
