### PR TITLE
Fire previous JS metrics via control

### DIFF
--- a/control/settings.py
+++ b/control/settings.py
@@ -389,6 +389,8 @@ LANG_GROUP_KEYS = {
     "nr": "778479e9ad7c4b00a898b61be6dbcac3"
 }
 
+METRIC_ENV = "replaceme"
+
 try:
     from local_settings import *  # flake8: noqa
 except ImportError:

--- a/control/testsettings.py
+++ b/control/testsettings.py
@@ -10,3 +10,4 @@ CELERY_ALWAYS_EAGER = True
 BROKER_BACKEND = 'memory'
 CELERY_RESULT_BACKEND = 'djcelery.backends.database:DatabaseBackend'
 RAVEN_CONFIG = {'dsn': None}
+METRIC_ENV = "test"

--- a/registration/tests.py
+++ b/registration/tests.py
@@ -1062,5 +1062,6 @@ class TestUpdateCreateVumiContactTask(AuthenticatedAPITestCase):
         }
         tasks.create_subscription(broken_contact, 'clinic')
         self.assertEqual(True, self.check_logs(
-            "Metric: u'test.clinic.sum.subscription_to_protocol_fail' [sum] -> 1"))
+            "Metric: u'test.clinic.sum.subscription_to_protocol_fail' " +
+            "[sum] -> 1"))
         self.assertEqual(1, self.check_logs_number_of_entries())

--- a/subscription/tests.py
+++ b/subscription/tests.py
@@ -328,7 +328,7 @@ class TestFireSummaryMetrics(TestCase):
 
     def check_logs(self, msg):
         if type(self.handler.logs) != list:
-            [logs] = self.handler.logs
+            logs = [self.handler.logs]
         else:
             logs = self.handler.logs
         for log in logs:


### PR DESCRIPTION
List here:
- [x] inc: `<env>.<name>.sum.json_to_jembi_success`
- [x] inc: `<env>.<name>.sum.json_to_jembi_fail`
- [x] inc: `<env>.<name>.sum.doc_to_jembi_success`
- [x] inc: `<env>.<name>.sum.doc_to_jembi_fail`
- [x] inc: `<env>.sum.subscriptions`
- [x] inc: `<env>.<name>.sum.subscription_to_protocol_success`
- [x] inc: `<env>.<name>.sum.subscription_to_protocol_fail`
