### PR TITLE
Explicit queue setting for 

### DIFF
--- a/control/settings.py
+++ b/control/settings.py
@@ -305,6 +305,9 @@ CELERY_ROUTES = {
     },
     'registration.tasks.update_create_vumi_contact': {
         'queue': 'priority',
+    },
+    'registration.tasks.vumi_fire_metric': {
+        'queue': 'priority',
     }
 }
 


### PR DESCRIPTION
`registration.tasks.vumi_fire_metric` is missing from settings.py
