### PR TITLE
ControlInterface go-http-api optout

### DIFF
--- a/controlinterface/tests.py
+++ b/controlinterface/tests.py
@@ -4,7 +4,6 @@ from django.test import TestCase, Client
 from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from subscription.models import Message, Subscription
-from go_http.optouts import OptOutsApiClient
 
 
 class MessageEditViewTests(TestCase):
@@ -117,9 +116,6 @@ class SubscriptionEditViewTests(TestCase):
             self.username,
             'testuser@example.com', self.password)
         self.client = Client()
-        self.optout_client = OptOutsApiClient(
-            auth_token="replaceme",
-            api_url="https://testing.optout/api/v1/go")
 
     def login(self):
         self.client.login(username='testuser', password='testpass')
@@ -251,6 +247,7 @@ class SubscriptionEditViewTests(TestCase):
         """
         If confirm cancel params, should cancel all, optout and confirm
         """
+        # Setup
         self.login()
         # Mock set_optout response
         optout_response = {
@@ -272,8 +269,11 @@ class SubscriptionEditViewTests(TestCase):
         activebefore = Subscription.objects.filter(
             to_addr="+271112", active=True).count()
         self.assertEqual(activebefore, 1)
+        # Execute
         response = self.client.post(
             reverse('controlinterface.views.subscription_edit'), optoutform)
+        # Check
+        self.assertEqual(len(responses.calls), 1)
         self.assertContains(response,
                             "All subscriptions for +271112 "
                             "have been cancelled")

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-celery-email==1.0.4
 pep8==1.5.7
 pyflakes==0.8.1
 django-tastypie==0.11.1
-go-http==0.2.4
+go-http==0.3.0
 redis==2.10.1
 besnappy==0.1.0
 django-bootstrap-form==3.1

--- a/snappybouncer/tests.py
+++ b/snappybouncer/tests.py
@@ -402,7 +402,7 @@ class BackfillTicketTest(TestCase):
 
         # response for vumi contact request
         responses.add(responses.GET,
-                      "http://go.vumi.org/api/v1/go/contacts/fakekey",
+                      "https://go.vumi.org/api/v1/go/contacts/fakekey",
                       json.dumps({"extra": {"clinic_code": "123457"}}),
                       status=200, content_type='application/json')
 
@@ -426,7 +426,7 @@ class BackfillTicketTest(TestCase):
                                 None, 112, "testtag")
         # response for vumi contact request
         responses.add(responses.GET,
-                      "http://go.vumi.org/api/v1/go/contacts/fakekey",
+                      "https://go.vumi.org/api/v1/go/contacts/fakekey",
                       json.dumps({"extra": {"clinic_code": "123458"}}),
                       status=200, content_type='application/json')
         # Execute

--- a/subsend/tests.py
+++ b/subsend/tests.py
@@ -193,7 +193,7 @@ class TestMessageFailure(TestCase):
                                           "Message 1 on accelerated",
                                           "response reason")
         responses.add(responses.PUT,
-                      "http://go.vumi.org/api/v1/go/http_api_nostream/"
+                      "https://go.vumi.org/api/v1/go/http_api_nostream/"
                       "replaceme/messages.json",
                       content_type='application/json;charset=utf-8',
                       body=exception)
@@ -206,7 +206,7 @@ class TestMessageFailure(TestCase):
     def test_subscriber_three_retries_on_500(self):
         subscriber = Subscription.objects.get(pk=1)
         responses.add(responses.PUT,
-                      "http://go.vumi.org/api/v1/go/http_api_nostream/"
+                      "https://go.vumi.org/api/v1/go/http_api_nostream/"
                       "replaceme/messages.json",
                       content_type='application/json;charset=utf-8',
                       status=577, body='{"error": "problems"}')
@@ -221,7 +221,7 @@ class TestMessageFailure(TestCase):
     def test_subscriber_other_httperror_code(self):
         subscriber = Subscription.objects.get(pk=1)
         responses.add(responses.PUT,
-                      "http://go.vumi.org/api/v1/go/http_api_nostream/"
+                      "https://go.vumi.org/api/v1/go/http_api_nostream/"
                       "replaceme/messages.json",
                       content_type='application/json;charset=utf-8',
                       status=405, body='{"error": "problems"}')
@@ -265,7 +265,7 @@ class TestHttpApiSender(TestCase):
             account_key="acc-key", conversation_key="conv-key",
             conversation_token="conv-token")
         self.assertEqual(sender.api_url,
-                         "http://go.vumi.org/api/v1/go/http_api_nostream")
+                         "https://go.vumi.org/api/v1/go/http_api_nostream")
 
     def check_request(self, request, method, data=None, headers=None):
         self.assertEqual(request.method, method)


### PR DESCRIPTION
Currently the opt-out link for subscriber edits just makes subscriptions inactive, it should also opt out the user.
