### PR TITLE
Iterate over cursor inside "with server_side_cursors():" block to avoid exiting block before we are done with the cursor.

### DIFF
--- a/control/utils.py
+++ b/control/utils.py
@@ -39,7 +39,8 @@ class CsvExportAdminMixin(DjangoObjectActions):
             Number of objects to include in each chunk. Default 1000.
         """
         with server_side_cursors(itersize=items_per_chunk):
-            return queryset.iterator()
+            for item in queryset.iterator():
+                yield item
 
     def export_csv(self, request, queryset):
         rows = itertools.chain(


### PR DESCRIPTION
We call the server_side_cursor helper with:

``` python
with server_side_cursors():
    return queryset.iterator()
```

but this means the server_side_cursor has already exited 

We should rather do:

``` python
with server_side_cursors():
    for item in queryset:
        yield item
```

Django's querysets `iterator()` method first yields once it has the first object, which is what is making me think that this change is worth a try for fixing the odd "returns only one row" CSV export issue.
