### PR TITLE
Don't use server side cursors

### DIFF
--- a/control/settings.py
+++ b/control/settings.py
@@ -172,7 +172,6 @@ INSTALLED_APPS = (
     'controlinterface',
     'nursereg',
     'django_object_actions',
-    'djorm_core.postgresql',
 )
 
 # A sample logging configuration. The only tangible logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,3 @@ djangorestframework==3.2.3
 django-filter==0.11.0
 lxml==3.4.4
 django-object-actions==0.8.0
-djorm-ext-core==0.7


### PR DESCRIPTION
Server side cursors are proving to be problematic. Without them, it means that the psql driver will cache the query data. But it will probably be okay for now, and it will fix our csv export problems. We will still be using `.interator()` to avoid django caching, and `StreamingHttpResponse` to avoid keeping the whole CSV in memory.
