### PR TITLE
Handle non ascii for csv export

### DIFF
--- a/control/utils.py
+++ b/control/utils.py
@@ -31,7 +31,8 @@ class CsvExportAdminMixin(DjangoObjectActions):
     def export_csv(self, request, queryset):
         rows = itertools.chain(
             (self.get_csv_header(), ),
-            (self.clean_csv_line(obj) for obj in queryset.iterator())
+            ([unicode(k).encode('utf-8') for k in i] for i in (
+                self.clean_csv_line(obj) for obj in queryset.iterator()))
         )
         pseudo_buffer = Echo()
         writer = csv.writer(pseudo_buffer)

--- a/control/utils.py
+++ b/control/utils.py
@@ -28,11 +28,16 @@ class CsvExportAdminMixin(DjangoObjectActions):
         CSV. Can also set the `csv_header` class variable.'''
         return self.csv_header
 
+    def _encode_csv_line(self, line):
+        return [unicode(item).encode('utf-8') for item in line]
+
     def export_csv(self, request, queryset):
         rows = itertools.chain(
             (self.get_csv_header(), ),
-            ([unicode(k).encode('utf-8') for k in i] for i in (
-                self.clean_csv_line(obj) for obj in queryset.iterator()))
+            (
+                self._encode_csv_line(self.clean_csv_line(obj))
+                for obj in queryset.iterator()
+            )
         )
         pseudo_buffer = Echo()
         writer = csv.writer(pseudo_buffer)

--- a/subscription/tests.py
+++ b/subscription/tests.py
@@ -439,6 +439,22 @@ class TestMessageAdmin(AdminCsvDownloadBase):
                 str(model.sequence_number), model.lang, model.content,
                 str(model.created_at), str(model.updated_at)])
 
+    def test_unicode_in_message(self):
+        '''If there are non-ascii characters in a field value, this should be
+        handled correctly.'''
+        ms = MessageSet.objects.all()[0]
+        Message.objects.create(
+            content=u'\U0001F4A9', message_set=ms, sequence_number=1)
+        rows = self.get_csv()
+        models = Message.objects.order_by('id')
+        self.assertEqual(len(rows), len(models))
+        for row, model in zip(rows, models):
+            self.assertEqual(row, [
+                str(model.id), str(model.message_set.id),
+                str(model.sequence_number), model.lang,
+                model.content.encode('utf-8'), str(model.created_at),
+                str(model.updated_at)])
+
 
 class TestMessageSetAdmin(AdminCsvDownloadBase):
     path = 'admin:subscription_messageset'

--- a/subscription/tests.py
+++ b/subscription/tests.py
@@ -476,7 +476,7 @@ class TestMessageSetAdmin(AdminCsvDownloadBase):
             if next_set:
                 next_set = str(next_set.id)
             else:
-                next_set = ''
+                next_set = str(next_set)
             self.assertEqual(row, [
                 str(model.id), model.short_name,
                 model.conversation_key, model.notes, next_set,


### PR DESCRIPTION
Currently, if there are any non-ascii characters, the export fails with no error message. We should handle the encoding of non-ascii characters.
