### PR TITLE
MOMZA-40 Make ID collection optional

### DIFF
--- a/nursereg/migrations/0002_auto__chg_field_nursereg_dob__chg_field_nursereg_id_type.py
+++ b/nursereg/migrations/0002_auto__chg_field_nursereg_dob__chg_field_nursereg_id_type.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'NurseReg.dob'
+        db.alter_column(u'nursereg_nursereg', 'dob', self.gf('django.db.models.fields.DateField')(null=True))
+
+        # Changing field 'NurseReg.id_type'
+        db.alter_column(u'nursereg_nursereg', 'id_type', self.gf('django.db.models.fields.CharField')(max_length=8, null=True))
+
+    def backwards(self, orm):
+
+        # User chose to not deal with backwards NULL issues for 'NurseReg.dob'
+        raise RuntimeError("Cannot reverse this migration. 'NurseReg.dob' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'NurseReg.dob'
+        db.alter_column(u'nursereg_nursereg', 'dob', self.gf('django.db.models.fields.DateField')())
+
+        # User chose to not deal with backwards NULL issues for 'NurseReg.id_type'
+        raise RuntimeError("Cannot reverse this migration. 'NurseReg.id_type' and its values cannot be restored.")
+        
+        # The following code is provided here to aid in writing a correct migration
+        # Changing field 'NurseReg.id_type'
+        db.alter_column(u'nursereg_nursereg', 'id_type', self.gf('django.db.models.fields.CharField')(max_length=8))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'nursereg.nursereg': {
+            'Meta': {'object_name': 'NurseReg'},
+            'cmsisdn': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'dmsisdn': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'dob': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'faccode': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'id_no': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'id_type': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'nurse_source': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'nurseregs'", 'to': u"orm['nursereg.NurseSource']"}),
+            'opted_out': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'optout_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'optout_reason': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'passport_origin': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'persal_no': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rmsisdn': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'sanc_reg_no': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'})
+        },
+        u'nursereg.nursesource': {
+            'Meta': {'object_name': 'NurseSource'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'nursesources'", 'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['nursereg']

--- a/nursereg/models.py
+++ b/nursereg/models.py
@@ -48,11 +48,12 @@ class NurseReg(models.Model):
     dmsisdn = models.CharField(max_length=255, null=True, blank=True)
     rmsisdn = models.CharField(max_length=255, null=True, blank=True)
     faccode = models.CharField(max_length=100)
-    id_type = models.CharField(max_length=8, choices=ID_TYPE_CHOICES)
+    id_type = models.CharField(max_length=8, null=True, blank=True,
+                               choices=ID_TYPE_CHOICES)
     id_no = models.CharField(max_length=100, null=True, blank=True)
     passport_origin = models.CharField(max_length=100, null=True,
                                        blank=True, choices=COUNTRY_CHOICES)
-    dob = models.DateField()
+    dob = models.DateField(null=True, blank=True)
     nurse_source = models.ForeignKey(NurseSource, related_name='nurseregs',
                                      null=False)
     persal_no = models.IntegerField(null=True, blank=True)

--- a/nursereg/tasks.py
+++ b/nursereg/tasks.py
@@ -178,12 +178,13 @@ def define_extras_registration(_extras, nursereg):
     _extras[u"nc_faccode"] = nursereg.faccode
     _extras[u"nc_is_registered"] = "true"
     _extras[u"nc_id_type"] = nursereg.id_type
-    _extras[u"nc_dob"] = nursereg.dob.strftime("%Y-%m-%d")
     if nursereg.id_type == "sa_id":
         _extras[u"nc_sa_id_no"] = nursereg.id_no
+        _extras[u"nc_dob"] = nursereg.dob.strftime("%Y-%m-%d")
     elif nursereg.id_type == "passport":
         _extras[u"nc_passport_num"] = nursereg.id_no
         _extras[u"nc_passport_country"] = nursereg.passport_origin
+        _extras[u"nc_dob"] = nursereg.dob.strftime("%Y-%m-%d")
     if nursereg.cmsisdn != nursereg.dmsisdn:
         _extras[u"nc_registered_by"] = nursereg.dmsisdn
     if nursereg.persal_no:

--- a/nursereg/tests.py
+++ b/nursereg/tests.py
@@ -1055,7 +1055,7 @@ class TestUpdateCreateVumiContactTask(AuthenticatedAPITestCase):
         nursereg = self.make_nursereg(
             post_data=TEST_REG_DATA["passport"])
         client = self.make_client()
-        presubs = Subscription .objects.all().count()
+        presubs = Subscription.objects.all().count()
         last_nursereg = NurseReg.objects.last()
         # Execute
         contact = tasks.update_create_vumi_contact.apply_async(


### PR DESCRIPTION
Should accept registrations where ID / passport / dob information is not provided, and accept this data when provided seperately.
