### PR TITLE
NurseConnect metrics - number of text messages sent

### DIFF
--- a/subsend/fixtures/test_subsend.json
+++ b/subsend/fixtures/test_subsend.json
@@ -90,6 +90,24 @@
     }
 },
 {
+    "pk": 6,
+    "model": "subscription.subscription",
+    "fields": {
+        "lang": "en",
+        "user_account": "80493284000",
+        "schedule": 4,
+        "completed": false,
+        "to_addr": "+271113",
+        "updated_at": "2014-07-23T13:48:05.720Z",
+        "message_set": 11,
+        "next_sequence_number": 3,
+        "active": true,
+        "contact_key": "82309423003",
+        "created_at": "2014-07-23T13:42:00Z",
+        "process_status": 0
+    }
+},
+{
     "pk": 1,
     "model": "subscription.message",
     "fields": {
@@ -171,6 +189,31 @@
         "content": "Message 3 in en on baby2",
         "message_set": 5,
         "sequence_number": 3
+    }
+},
+{
+    "pk": 8,
+    "model": "subscription.message",
+    "fields": {
+        "lang": "en",
+        "created_at": "2014-07-23T21:14:45.374Z",
+        "updated_at": "2014-07-23T21:14:45.374Z",
+        "content": "Message 3 in en on nurseconnect",
+        "message_set": 11,
+        "sequence_number": 3
+    }
+},
+{
+    "pk": 9,
+    "model": "subscription.message",
+    "fields": {
+        "lang": "en",
+        "created_at": "2014-07-23T21:14:45.374Z",
+        "updated_at": "2014-07-23T21:14:45.374Z",
+        "content": "Message 4 in en on nurseconnect",
+        "category": "info",
+        "message_set": 11,
+        "sequence_number": 4
     }
 }
 ]


### PR DESCRIPTION
Note: `<env>.sum.nurseconnect_auto` has already been firing a `sum` metric each time the end of the `nurseconnect` messageset is reached.  This can be used for tracking the `Number of nurses/midwives who have finished the programme` info.
- [x] `<env>.sum.nurseconnect_auto`
- [x] `<env>.sum.nurseconnect.sms.outbound`
- [x] `<env>.sum.nurseconnect.<category>.sms.outbound`

`<category>` needs to be set for the existing messages - `informational` or `motivational_feedback`
